### PR TITLE
Add results table for CCC

### DIFF
--- a/content/watch/competitions/cccc.md
+++ b/content/watch/competitions/cccc.md
@@ -10,7 +10,39 @@ Organizers pick participants based on engine's entertainment value. Particularly
 
 ## Results of past competitions
 
-|Season|Time control|Lc0 final position|
-|------|------------|------------------|
-
-TODO(fill that table)
+| Season                  | Year | Time control   | Lc0 final position   |
+| ----------------------- | ---- | -------------- | -------------------- |
+| CCC 21: Bullet          | 2023 | 1+1            | 5                    |
+| CCC 21: Rapid           | 2023 | 10+3           | 2                    |
+| CCC 21: Blitz           | 2023 | 3+2            | 3                    |
+| CCC 20: Bullet          | 2023 | 1+1            | 4                    |
+| CCC 20: Rapid           | 2023 | 10+3           | 2                    |
+| CCC 20: Blitz           | 2023 | 3+2            | ?                    |
+| CCC 19: Bullet          | 2023 | 1+1            | ?                    |
+| CCC 19: Rapid           | 2022 | 15+3           | 2                    |
+| CCC 19: Blitz           | 2022 | 5+5            | ?                    |
+| CCC 18: Rapid           | 2022 | 15+3           | 2                    |
+| CCC 17: Blitz           | 2022 | 5+5            | 2                    |
+| CCC 17: Bullet          | 2022 | 2+1            | ?                    |
+| CCC 17: Rapid           | 2022 | 15+3           | ?                    |
+| CCC 16: Blitz           | 2022 | 5+5            | ?                    |
+| CCC 16: Bullet          | 2021 | 2+1            | ?                    |
+| CCC 16: Rapid           | 2021 | 15+3           | 2                    |
+| CCC Chess 960 Blitz     | 2021 | 5+5            | ?                    |
+| CCC Blitz 2021          | 2021 | 5+5            | 2                    |
+| CCC Rapid 2021          | 2021 | 15+3           | 2                    |
+| CCC Blitz 2020          | 2020 | 5+5            | 2                    |
+| CCC 14                  | 2020 | 15+5, 5+2, 1+1 | 1                    |
+| CCC 13: Heptagonal      | 2020 | 5+5            | 1                    |
+| CCC 12: Bullet Madness! | 2020 | 1+1            | 1                    |
+| CCC 11                  | 2019 | 30+5           | 1                    |
+| CCC 10: Double Digits   | 2019 | 10+3           | ? (1 as Leelenstein) |
+| CCC 9: The Gauntlet     | 2019 | 5+2, 10+5      | 3 (2 as Leelenstein) |
+| CCC 8: Deep Dive        | 2019 | 15+5           | 2                    |
+| CCC 7: Blitz Bonanza    | 2019 | 5+2            | 1                    |
+| CCC 6: Winter Classic   | 2019 | 10+10          | 2                    |
+| CCC 5: Escalation       | 2019 | 10+5           | ?                    |
+| CCC 4: Bullet Brawl     | 2019 | 1+2            | 2                    |
+| CCC 3: Rapid Redux      | 2019 | 30+5           | 2                    |
+| CCC 2: Blitz Battle     | 2018 | 5+2            | 3                    |
+| CCC 1: Rapid Rumble     | 2018 | 15+5           | 3                    |


### PR DESCRIPTION
This PR adds the results table for the [Chess.com computer chess championship](https://chess.com/cccc) (CCC).

The information is sourced from the [Wikipedia page](https://en.wikipedia.org/wiki/Chess.com#Chess.com_Computer_Chess_Championship), from Chess.com announcement posts and from [manual searches on the CCC page](https://www.chess.com/computer-chess-championship), filtering games by events.

There is still some information missing as it takes a long time to put together.
I suggest to add the missing pieces in separate PRs.