### PR TITLE
Small GoAT Adjustment

### DIFF
--- a/themes/leela/assets/css/main.css
+++ b/themes/leela/assets/css/main.css
@@ -587,6 +587,12 @@ footer {
     color: var(--footer-icon-color);
 }
 
+/* GoAT Graphs */
+div.goat {
+  width: 80%;
+  margin: auto;
+}
+
 /* Blog list */
 .blog-summary {
     margin-top: 48px;


### PR DESCRIPTION
Closes #148

<img width="1150" height="827" alt="image" src="https://github.com/user-attachments/assets/b0df9fd8-fcd2-40f9-bcc8-9b7e96833db9" />

While it does not perfectly scale the GoAT, it still does width based scaling but makes things a bit smaller. We can force it to be, say 12pt font, vs the default 16pt (1rem) font but it will break some graphs. 

It might be a better idea to look into Mermaid Graph support which seems to have a bit more control. 