### PR TITLE
Add tracking consent popup and update analytics loading logic

### DIFF
--- a/themes/leela/assets/css/main.css
+++ b/themes/leela/assets/css/main.css
@@ -1094,3 +1094,59 @@ footer {
   position: relative;
   z-index: 1;
 }
+
+
+/* Tracking Consent Popup Styles */
+#consent-popup {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-bg-primary);
+  border-top: 1px solid var(--color-border-primary);
+  padding: 1rem;
+  box-shadow: 0 -2px 10px var(--shadow-color);
+  font-family: var(--main-font);
+  color: var(--color-text-primary);
+  z-index: 9999;
+}
+
+.consent-popup-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+
+#consent-popup p {
+  margin: 0;
+  font-size: var(--font-size-h6);
+  color: var(--color-text-secondary);
+}
+
+#consent-popup button {
+  padding: 0.5rem 1rem;
+  border: none;
+  cursor: pointer;
+  font-family: var(--main-font);
+  font-size: var(--font-size-h6);
+}
+
+#accept-consent {
+  background: var(--color-accent);
+  color: var(--color-button-text);
+}
+
+#decline-consent {
+  background: var(--color-gray-300);
+  color: var(--color-black);
+}
+
+@media (prefers-color-scheme: dark) {
+  #decline-consent {
+    background: var(--color-gray-600);
+    color: var(--color-white);
+  }
+}

--- a/themes/leela/layouts/_partials/analytics.html
+++ b/themes/leela/layouts/_partials/analytics.html
@@ -1,14 +1,34 @@
 {{- if hugo.IsServer -}}
-  <!-- Dont add Google analytics to localhost -->
+  <!-- Don't add Google Analytics to localhost -->
 {{ else }}
-    {{ if .Site.Params.google_analytics_id }}
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
-        <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+  {{ if .Site.Params.google_analytics_id }}
+    <script>
+    (function() {
+      const consentKey = 'gtmConsent';
+      const gaId = '{{- .Site.Params.google_analytics_id -}}';
 
-        gtag('config', '{{- .Site.Params.google_analytics_id -}}');
-        </script>
-    {{ end }}
+      function loadAnalytics() {
+        const gaScript = document.createElement('script');
+        gaScript.async = true;
+        gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+        document.head.appendChild(gaScript);
+
+        gaScript.onload = function() {
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', gaId);
+        };
+      }
+
+      // Load immediately if consent already given
+      if (localStorage.getItem(consentKey) === 'true') {
+        loadAnalytics();
+      }
+
+      // Expose to consent popup
+      window.loadAnalyticsWithConsent = loadAnalytics;
+    })();
+    </script>
+  {{ end }}
 {{ end }}

--- a/themes/leela/layouts/_partials/head.html
+++ b/themes/leela/layouts/_partials/head.html
@@ -16,3 +16,4 @@
   <script src="//pgn.chessbase.com/cbreplay.js" type="text/javascript"></script>  
 {{ end }}
 {{ partialCached "analytics.html" . }}
+{{ partialCached "tracking-consent.html" . }}

--- a/themes/leela/layouts/_partials/tracking-consent.html
+++ b/themes/leela/layouts/_partials/tracking-consent.html
@@ -1,0 +1,62 @@
+<!-- Consent Popup Partial -->
+<div id="consent-popup" style="display:none;">
+  <div class="consent-popup-content">
+    <p>We use cookies and similar technologies to improve your experience and analyze traffic. 
+       Do you consent to Google Analytics?</p>
+      {{ if hugo.IsServer }}
+        <p style="font-size: 0.85em; color: var(--color-text-tertiary);">
+          <strong>Note:</strong> You are running the site locally — analytics will not actually be loaded.
+        </p>
+      {{ end }}
+    <div>
+      <button id="accept-consent">Accept</button>
+      <button id="decline-consent">Decline</button>
+    </div>
+  </div>
+</div>
+
+<script>
+
+  const consentKey = 'gtmConsent';
+  const consentPopup = document.getElementById('consent-popup');
+  const acceptBtn = document.getElementById('accept-consent');
+  const declineBtn = document.getElementById('decline-consent');
+
+  function hasDoNotTrackEnabled() {
+    return (
+      navigator.doNotTrack === "1" || // Most browsers
+      navigator.doNotTrack === "yes" || // Older Firefox
+      window.doNotTrack === "1" || // Some IE versions
+      navigator.msDoNotTrack === "1" // IE 10+
+    );
+  }
+
+  function acceptConsent() {
+    localStorage.setItem(consentKey, 'true');
+    consentPopup.style.display = 'none';
+    if (typeof window.loadAnalyticsWithConsent === 'function') {
+      window.loadAnalyticsWithConsent();
+    }
+  }
+
+  function declineConsent() {
+    localStorage.setItem(consentKey, 'false');
+    consentPopup.style.display = 'none';
+  }
+
+  // Skip entirely if DNT is enabled
+  if (hasDoNotTrackEnabled()) {
+    localStorage.setItem(consentKey, 'false'); // Ensure analytics doesn't load
+    /*  return;  */
+  }
+
+  // Show popup if no decision yet
+  const storedConsent = localStorage.getItem(consentKey);
+  if (!storedConsent) {
+    consentPopup.style.display = 'block';
+  }
+
+  acceptBtn.addEventListener('click', acceptConsent);
+  declineBtn.addEventListener('click', declineConsent);
+
+</script>


### PR DESCRIPTION
Adds a consent request to the base page. Google tracking will only start if the user consents. The consent popup respects the browser's Do Not Track setting: if DNT is enabled, the popup will not be shown and tracking will be disabled.