### PR TITLE
Enable pagination on blog

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,6 +59,10 @@ enableMissingTranslationPlaceholders = true
     url = "/blog"
     weight = 70
 
+# Used for blog pagination
+[pagination]
+  pagerSize = 10  
+
 [params]
   lc0version="v0.32.0"
   google_analytics_id="G-MC971PFSYE"

--- a/layouts/blog/section.html
+++ b/layouts/blog/section.html
@@ -3,7 +3,8 @@
     <h1 class="title">{{ .Title }}</h1>
 
     {{if default true .Params.show_contents}}
-    {{ range.Pages }}
+    {{ $paginator := .Paginate .Pages }}
+    {{ range $paginator.Pages }}
         <div class="blog-summary">            
             <div class="blog-summary-title">
                 <a href="{{ .Permalink }}">
@@ -15,6 +16,17 @@
             {{ end}}
             <p>{{ .Summary }}</p>
         </div>
+    {{ end }}
+
+    <!-- Pagination navigation -->
+    {{ if gt $paginator.TotalPages 1 }}
+    <nav class="pagination">
+        <a {{ if $paginator.HasPrev }}href="{{ $paginator.Prev.URL }}" class="pagination-prev" {{ else }}class="pagination-prev pagination-disabled"{{ end }}>← Previous</a>
+
+        <span class="pagination-current">Page {{ $paginator.PageNumber }} of {{ $paginator.TotalPages }}</span>
+        
+        <a {{ if $paginator.HasNext }}href="{{ $paginator.Next.URL }}" class="pagination-next" {{ else }}class="pagination-next pagination-disabled"{{ end }}>Next →</a>
+        </nav>
     {{ end }}
     {{ end }}
 {{ end }}

--- a/themes/leela/assets/css/main.css
+++ b/themes/leela/assets/css/main.css
@@ -658,6 +658,25 @@ footer {
     font-size: 1.2rem;
 }
 
+nav.pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 2rem 0;
+    padding: 1rem 0;
+}
+
+.pagination-prev, .pagination-next {
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+}
+
+.pagination-disabled {
+    color: var(--color-text-tertiary);
+    pointer-events: none;
+}
+
+
 /* Base Alert Styles */
 .alert {
   padding: 1rem;


### PR DESCRIPTION
<img width="1446" height="316" alt="image" src="https://github.com/user-attachments/assets/507a4a78-9891-41c7-8148-9e16ce1e0e45" />

As we add more blog posts, this is page is only going to get longer. I don't think we will ever get to the point of the networks page on the training website, but we might as well do this now.